### PR TITLE
Security Fix for Prototype Pollution in mquery

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,6 +170,9 @@ exports.mergeClone = function mergeClone(to, from) {
 
   while (i--) {
     key = keys[i];
+    if (specialProperties.indexOf(key) !== -1) {
+      continue;
+    }
     if ('undefined' === typeof to[key]) {
       to[key] = clone(from[key]);
     } else {


### PR DESCRIPTION
### 📊 Metadata *

mquery is aware of the risk of prototype pollution in its exported functions ``cloneObject()`` and ``merge()`` and readily present protection by checking the key in ``var specialProperties = ['__proto__', 'constructor', 'prototype']``. However, the current protection misses to protect another exported function ``mergeClone()``. As a result, the latest version 3.2.4 is still vulnerable to prototype pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-mquery/

### ⚙️ Description *

Filter out ``specialProperties = ['__proto__', 'constructor', 'prototype']`` .

### 💻 Technical Description *

Place the protection code in ``mergeClone()``:
`` if (specialProperties.indexOf(key) !== -1) { continue; }``

### 🐛 Proof of Concept (PoC) *
```
// PoC.js version of mquery is 3.2.4
mquery = require('mquery');
var malicious_payload = '{"__proto__":{"polluted":"HACKED"}}';
console.log('Before:', {}.polluted); // undefined
mquery.utils.mergeClone({}, JSON.parse(malicious_payload));
console.log('After:', {}.polluted); // HACKED
```
### 🔥 Proof of Fix (PoF) *
```
// PoC.js version of mquery is 3.2.4
mquery = require('mquery');
var malicious_payload = '{"__proto__":{"polluted":"HACKED"}}';
console.log('Before:', {}.polluted); // undefined
mquery.utils.mergeClone({}, JSON.parse(malicious_payload));
console.log('After:', {}.polluted); // undefined
```
### 👍 User Acceptance Testing (UAT)

N/A

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-mquery/
